### PR TITLE
Fix allocated function and withdraw

### DIFF
--- a/src/Sale.sol
+++ b/src/Sale.sol
@@ -397,7 +397,7 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
 
     /// @return the amount of tokens already allocated
     function allocated() public view returns (uint256) {
-        return Math.min(totalUncappedAllocations, totalTokensForSale);
+        return Math.min(totalUncappedAllocations, maxTarget);
     }
 
     //


### PR DESCRIPTION
Currently the `allocated` function that is used in the `withdraw` function to calculated the amount of tokens the owner is able to withdraw after the sale ends was still using the `totalTokensForSale` instead of `maxTarget`, which is now the correct parameter that defines the sale size.

