### PR TITLE
Prevent admin rugpull on a failed sale, as reported on #25

### DIFF
--- a/src/Sale.sol
+++ b/src/Sale.sol
@@ -169,6 +169,7 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
         require(block.timestamp > end, "sale not ended yet");
         require(!withdrawn, "already withdrawn");
         require(custodian != address(0), CustodianNotSet());
+        require(totalUncappedAllocations >= minTarget, "minTarget not reached");
 
         withdrawn = true;
 

--- a/test/SaleLegacy.d.sol
+++ b/test/SaleLegacy.d.sol
@@ -122,6 +122,7 @@ contract SaleLegacyTest is TestSetup {
         uint256 mintAmount = usdc(2);
         uint256 buyAmount = usdc(2);
 
+        ctx.sale.setMinTarget(buyAmount);
         mintUsdc(alice, mintAmount);
 
         vm.startPrank(alice);
@@ -142,6 +143,7 @@ contract SaleLegacyTest is TestSetup {
         uint256 mintAmount = usdc(2);
         uint256 buyAmount = usdc(2);
 
+        ctx.sale.setMinTarget(buyAmount);
         mintUsdc(alice, mintAmount);
 
         vm.startPrank(alice);
@@ -192,7 +194,10 @@ contract SaleLegacyTest is TestSetup {
         vm.stopPrank();
 
         uint256 ownerBalanceAfter = ctx.usdc.balanceOf(address(this));
-        assertEq(ownerBalanceAfter - ownerBalanceBefore, (amount * 2) - aliceRefund - bobRefund);
+        assertEq(
+            ownerBalanceAfter - ownerBalanceBefore,
+            (amount * 2) - aliceRefund - bobRefund
+        );
     }
 
     function test_SetIndividualCap() public {
@@ -240,7 +245,9 @@ contract SaleLegacyTest is TestSetup {
         assertEq(ctx.sale.refundAmount(alice), 0);
     }
 
-    function test_RefundAmountIsZeroIfIndividualCapIsHigherThanInvestedTotal() public {
+    function test_RefundAmountIsZeroIfIndividualCapIsHigherThanInvestedTotal()
+        public
+    {
         ctx.sale.setMinTarget(usdc(1));
         ctx.sale.setMaxTarget(usdc(10));
 

--- a/test/SaleMinTargetNotReached.d.sol
+++ b/test/SaleMinTargetNotReached.d.sol
@@ -76,4 +76,28 @@ contract SaleMinTargetNotReachedTest is TestSetup {
 
         assertEq(ctx.usdc.balanceOf(address(ctx.sale)), 0);
     }
+
+    function test_WithdrawRevertsWhenMinTargetNotReached() public {
+        ctx.sale.setMinTarget(1 ether);
+
+        uint256 amount = (ctx.sale.minTarget() / 2) - (usdc(1));
+
+        invest(alice, amount);
+        invest(bob, amount);
+
+        assertEq(ctx.sale.totalUncappedAllocations(), amount * 2);
+        assertLt(ctx.sale.totalUncappedAllocations(), ctx.sale.minTarget());
+
+        endSale();
+        setCap();
+
+        assertEq(ctx.sale.allocation(alice), 0);
+        assertEq(ctx.sale.refundAmount(alice), amount);
+
+        vm.expectRevert("minTarget not reached");
+        ctx.sale.withdraw();
+
+        assertEq(ctx.usdc.balanceOf(address(ctx.sale)), amount * 2);
+        assertEq(ctx.usdc.balanceOf(address(this)), 0);
+    }
 }


### PR DESCRIPTION
This demonstrates the vulnerability reported at #25.